### PR TITLE
document link added for style citation's format

### DIFF
--- a/intellect-newgen-style.csl
+++ b/intellect-newgen-style.csl
@@ -6,15 +6,13 @@
     <title-short>INS</title-short>
     <id>http://www.zotero.org/styles/intellect-newgen-style</id>
     <link href="http://www.zotero.org/styles/intellect-newgen-style" rel="self"/>
+    <link href="https://storage.googleapis.com/cegenius-open-files/intellect_cslfile/document.html" rel="documentation"/>
     <category citation-format="author-date"/>
     <category field="social_science"/>
     <summary>Style for Intellect Newgen Style</summary>
     <updated>2020-08-19T09:16:06+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <info>
-     <link href="https://storage.googleapis.com/cegenius-open-files/intellect_cslfile/document.html" rel="documentation"/>
-   </info>
   <macro name="conditionalusetitle">
     <choose>
       <if type="article-newspaper article-magazine" match="any">


### PR DESCRIPTION
Independent styles should have a "documentation" link that points to a description of the style's citation format. For journals, this is typically the "instructions to authors" webpage. If a style guide is only available in print, provide a URL that allows us to locate a paper copy.